### PR TITLE
Refactor launchSettings.json files to standardize profile names and i…

### DIFF
--- a/src/HelloAspireApp.ApiService/Properties/launchSettings.json
+++ b/src/HelloAspireApp.ApiService/Properties/launchSettings.json
@@ -1,23 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:5412",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
+    "HelloAspireApp.ApiService": {
       "applicationUrl": "https://localhost:7346;http://localhost:5412",
+      "commandName": "Project",
+      "dotnetRunMessages": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "launchBrowser": false
+    },
+    "http": {
+      "applicationUrl": "http://localhost:5412",
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "launchBrowser": false
     }
   }
 }

--- a/src/HelloAspireApp.AppHost/Properties/launchSettings.json
+++ b/src/HelloAspireApp.AppHost/Properties/launchSettings.json
@@ -1,29 +1,29 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "https": {
+    "HelloAspireApp.AppHost": {
+      "applicationUrl": "https://localhost:17087;http://localhost:15231",
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:17087;http://localhost:15231",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21271",
+        "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22176"
-      }
+      },
+      "launchBrowser": true
     },
     "http": {
+      "applicationUrl": "http://localhost:15231",
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:15231",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19055",
+        "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20101"
-      }
+      },
+      "launchBrowser": true
     }
   }
 }

--- a/src/HelloAspireApp.Web/Properties/launchSettings.json
+++ b/src/HelloAspireApp.Web/Properties/launchSettings.json
@@ -1,23 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5251",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
+    "HelloAspireApp.Web": {
       "applicationUrl": "https://localhost:7101;http://localhost:5251",
+      "commandName": "Project",
+      "dotnetRunMessages": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "launchBrowser": true
+    },
+    "http": {
+      "applicationUrl": "http://localhost:5251",
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "launchBrowser": true
     }
   }
 }


### PR DESCRIPTION
This pull request updates the `launchSettings.json` files across multiple projects to rename profiles to match their respective project names, consolidate settings, and ensure consistency in configuration for `applicationUrl`, `environmentVariables`, and `launchBrowser` behavior.

### Updates to profile names and settings:

* [`src/HelloAspireApp.ApiService/Properties/launchSettings.json`](diffhunk://#diff-f8118e3f320e1d11cbd0e25ee12113eb3cdc2f833b3dfd70b714871f4d6bb96dL4-R20): Renamed the `http` profile to `HelloAspireApp.ApiService`, updated `applicationUrl` to include both HTTP and HTTPS endpoints, and consolidated `launchBrowser` settings.
* [`src/HelloAspireApp.AppHost/Properties/launchSettings.json`](diffhunk://#diff-c1fae52b95b168586536e555c3d5cb7d74ca967aea2083cca03c096d250300a3L4-R26): Renamed the `https` profile to `HelloAspireApp.AppHost`, updated `applicationUrl` with both protocols, adjusted `DOTNET_ENVIRONMENT` placement within `environmentVariables`, and ensured consistent `launchBrowser` settings.
* [`src/HelloAspireApp.Web/Properties/launchSettings.json`](diffhunk://#diff-1c0e8117e9366efe30849f915d521dcf3b7c9c69eadff2fb41b502ec00f14f6dL4-R20): Renamed the `http` profile to `HelloAspireApp.Web`, updated `applicationUrl` to include both HTTP and HTTPS endpoints, and standardized `launchBrowser` settings.… Improve clarity