### PR TITLE
Swamy/23jun work

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   <!-- Package versions for Aspire -->
   <ItemGroup Label="Aspire">
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure" Version="9.3.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure" Version="9.3.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="9.3.1" />
     <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.3.1" />

--- a/src/HelloAspireApp.AppHost/FixedNameInfrastructureResolver.cs
+++ b/src/HelloAspireApp.AppHost/FixedNameInfrastructureResolver.cs
@@ -3,7 +3,6 @@ using Azure.Provisioning.AppContainers;
 using Azure.Provisioning.ContainerRegistry;
 using Azure.Provisioning.OperationalInsights;
 using Azure.Provisioning.Primitives;
-using Azure.Provisioning.Redis;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.Configuration;
 

--- a/src/HelloAspireApp.ServiceDefaults/Extensions.cs
+++ b/src/HelloAspireApp.ServiceDefaults/Extensions.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.ServiceDiscovery;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;


### PR DESCRIPTION
This pull request includes a few changes related to package updates and code cleanup. The most notable changes involve updating the version of the `Aspire.Hosting.Azure` package and removing unused `using` directives from two files.

### Package updates:

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L10-R10): Updated the version of `Aspire.Hosting.Azure` from `9.3.1` to `9.3.2`.

### Code cleanup:

* [`src/HelloAspireApp.AppHost/FixedNameInfrastructureResolver.cs`](diffhunk://#diff-e27051b26a7a2ff1d2ede9de3061b8859b3a775fcd0644c3a8b6a204e938c9bdL6): Removed an unused `using` directive for `Azure.Provisioning.Redis`.
* [`src/HelloAspireApp.ServiceDefaults/Extensions.cs`](diffhunk://#diff-b1a3fbee5f19c3876bf2eaeb2f8868f5cd9a9b7ead7b9d3c9de9be9fc54dbe5bL6): Removed an unused `using` directive for `Microsoft.Extensions.ServiceDiscovery`.