### PR TITLE
Swamy/08jul work

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,3 +313,4 @@ azd infra generate --force
 # Manual Bicep file editing required...
 azd up
 ```
+

--- a/README.md
+++ b/README.md
@@ -179,6 +179,15 @@ azd infra generate --force
 
 # Authenticate with Azure
 azd auth login --scope https://management.azure.com//.default
+
+$env:AZURE_ENV_SUFFIX='D'
+azd up -e aspire-dev-001
+
+$env:AZURE_ENV_SUFFIX='T'
+azd up -e aspire-test-001
+
+$env:AZURE_ENV_SUFFIX='S'
+azd up -e aspire-stage-001
 ```
 
 #### First-Time Setup

--- a/src/HelloAspireApp.AppHost/infra/cache/cache.module.bicep
+++ b/src/HelloAspireApp.AppHost/infra/cache/cache.module.bicep
@@ -1,8 +1,11 @@
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
+@description('Environment suffix for resource naming (D/T/S/P)')
+param environmentSuffix string
+
 resource cache 'Microsoft.Cache/redis@2024-11-01' = {
-  name: 'sv-cache-T'
+  name: 'sv-cache-${environmentSuffix}'
   location: location
   properties: {
     sku: {

--- a/src/HelloAspireApp.AppHost/infra/main.bicep
+++ b/src/HelloAspireApp.AppHost/infra/main.bicep
@@ -36,6 +36,7 @@ module cache 'cache/cache.module.bicep' = {
   scope: rg
   params: {
     location: location
+    environmentSuffix: environmentSuffix
   }
 }
 module cache_roles 'cache-roles/cache-roles.module.bicep' = {


### PR DESCRIPTION
This pull request introduces changes to support environment-specific configurations for Azure deployments and updates the documentation accordingly. The most significant changes include adding an `environmentSuffix` parameter to resource definitions, modifying resource naming conventions, and updating the `README.md` with new deployment instructions.

### Environment-specific configurations:

* [`src/HelloAspireApp.AppHost/infra/cache/cache.module.bicep`](diffhunk://#diff-99b5e823e32202f5465efd8ad1e0be829360b74043623af77aaafd108eabc251R4-R8): Added a new `environmentSuffix` parameter to allow dynamic resource naming based on the environment (e.g., D, T, S, P). Updated the `cache` resource name to use this parameter.
* [`src/HelloAspireApp.AppHost/infra/main.bicep`](diffhunk://#diff-03312c64375e41223f43bbe96ed808068991bfcd52b0fc01c28e416a7699255aR39): Passed the `environmentSuffix` parameter to the `cache` module to ensure consistent environment-specific naming across resources.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182-R190): Added instructions for setting the `AZURE_ENV_SUFFIX` environment variable and deploying to specific environments (`aspire-dev-001`, `aspire-test-001`, `aspire-stage-001`) using `azd up`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R316): Minor formatting adjustment to improve readability.