### PR TITLE
Fix environment name casing in Azure deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: dev
+    environment: Dev
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy-to-azure.yml` file. The change updates the `environment` value from `dev` to `Dev` to ensure proper casing consistency.