### PR TITLE
Remove federation credentials section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,11 +553,3 @@ azd infra generate --force
 # Manual Bicep file editing required...
 azd up
 ```
-
-## Federation Credentials
-
-```text
-repo:Swamy-s-Tech-Skills-Academy/aspire-demo89x:ref:refs/heads/main
-
-repo:Swamy-s-Tech-Skills-Academy/aspire-demo89x:environment:Dev
-```


### PR DESCRIPTION
This pull request removes outdated documentation related to Federation Credentials from the `README.md` file.

Documentation updates:

* Removed the "Federation Credentials" section, which included references to a specific repository and environment, as it is no longer relevant. (`README.md`, [README.mdL556-L563](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L556-L563))