### PR TITLE
Add parameters for existing Log Analytics workspace and update resour…

### DIFF
--- a/src/HelloAspireApp.AppHost/infra/main.bicep
+++ b/src/HelloAspireApp.AppHost/infra/main.bicep
@@ -15,6 +15,15 @@ param environmentSuffix string
 @description('Resource group name override (optional)')
 param resourceGroupName string = ''
 
+@description('Resource ID of an existing Log Analytics workspace to use')
+param existingLogAnalyticsWorkspaceId string = ''
+
+@description('Customer ID of the existing Log Analytics workspace')
+param existingLogAnalyticsWorkspaceCustomerId string = ''
+
+@description('Primary shared key of the existing Log Analytics workspace')
+param existingLogAnalyticsWorkspaceSharedKey string = ''
+
 // Function to convert Azure location to region abbreviation
 var regionAbbreviations = {
   eastus: 'use'
@@ -49,6 +58,9 @@ module resources 'resources.bicep' = {
     tags: tags
     environmentSuffix: environmentSuffix
     regionAbbreviation: regionAbbreviation
+    existingLogAnalyticsWorkspaceId: existingLogAnalyticsWorkspaceId
+    existingLogAnalyticsWorkspaceCustomerId: existingLogAnalyticsWorkspaceCustomerId
+    existingLogAnalyticsWorkspaceSharedKey: existingLogAnalyticsWorkspaceSharedKey
   }
 }
 

--- a/src/HelloAspireApp.AppHost/infra/main.parameters.json
+++ b/src/HelloAspireApp.AppHost/infra/main.parameters.json
@@ -13,6 +13,15 @@
     },
     "resourceGroupName": {
       "value": "${AZURE_RESOURCE_GROUP}"
+    },
+    "existingLogAnalyticsWorkspaceId": {
+      "value": "${EXISTING_LOG_ANALYTICS_WORKSPACE_ID}"
+    },
+    "existingLogAnalyticsWorkspaceCustomerId": {
+      "value": "${EXISTING_LOG_ANALYTICS_WORKSPACE_CUSTOMER_ID}"
+    },
+    "existingLogAnalyticsWorkspaceSharedKey": {
+      "value": "${EXISTING_LOG_ANALYTICS_WORKSPACE_SHARED_KEY}"
     }
   }
 }

--- a/src/HelloAspireApp.AppHost/infra/resources.bicep
+++ b/src/HelloAspireApp.AppHost/infra/resources.bicep
@@ -10,6 +10,15 @@ param regionAbbreviation string
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
+@description('Resource ID of an existing Log Analytics workspace to use')
+param existingLogAnalyticsWorkspaceId string = ''
+
+@description('Customer ID of the existing Log Analytics workspace')
+param existingLogAnalyticsWorkspaceCustomerId string = ''
+
+@description('Primary shared key of the existing Log Analytics workspace')
+param existingLogAnalyticsWorkspaceSharedKey string = ''
+
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: 'sv-mi-${environmentSuffix}-${regionAbbreviation}'
   location: location
@@ -42,7 +51,8 @@ resource caeMiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
 }
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+// Create Log Analytics workspace only if an existing one is not provided
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = if (empty(existingLogAnalyticsWorkspaceId)) {
   name: 'sv-law-${environmentSuffix}-${regionAbbreviation}'
   location: location
   properties: {
@@ -51,6 +61,12 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10
     }
   }
   tags: tags
+}
+
+// Get reference to existing Log Analytics workspace if ID is provided
+resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = if (!empty(existingLogAnalyticsWorkspaceId)) {
+  name: last(split(existingLogAnalyticsWorkspaceId, '/'))
+  scope: resourceGroup(split(existingLogAnalyticsWorkspaceId, '/')[2], split(existingLogAnalyticsWorkspaceId, '/')[4])
 }
 
 resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-02-02-preview' = {
@@ -66,8 +82,12 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-02-02-p
     appLogsConfiguration: {
       destination: 'log-analytics'
       logAnalyticsConfiguration: {
-        customerId: logAnalyticsWorkspace.properties.customerId
-        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
+        customerId: !empty(existingLogAnalyticsWorkspaceId)
+          ? existingLogAnalyticsWorkspaceCustomerId
+          : logAnalyticsWorkspace.properties.customerId
+        sharedKey: !empty(existingLogAnalyticsWorkspaceId)
+          ? existingLogAnalyticsWorkspaceSharedKey
+          : logAnalyticsWorkspace.listKeys().primarySharedKey
       }
     }
   }
@@ -84,8 +104,12 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-02-02-p
 output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
 output MANAGED_IDENTITY_NAME string = managedIdentity.name
 output MANAGED_IDENTITY_PRINCIPAL_ID string = managedIdentity.properties.principalId
-output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = logAnalyticsWorkspace.name
-output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = logAnalyticsWorkspace.id
+output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = !empty(existingLogAnalyticsWorkspaceId)
+  ? last(split(existingLogAnalyticsWorkspaceId, '/'))
+  : logAnalyticsWorkspace.name
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = !empty(existingLogAnalyticsWorkspaceId)
+  ? existingLogAnalyticsWorkspaceId
+  : logAnalyticsWorkspace.id
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer
 output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = managedIdentity.id
 output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.name


### PR DESCRIPTION
This pull request introduces support for optionally using an existing Log Analytics workspace in the Azure infrastructure deployment. The changes include adding new parameters, conditional logic for resource creation, and updates to output values to accommodate the use of an existing workspace.

### Support for Existing Log Analytics Workspace:

* **New Parameters**: Added parameters in `src/HelloAspireApp.AppHost/infra/main.bicep` and `src/HelloAspireApp.AppHost/infra/resources.bicep` to accept the resource ID, customer ID, and shared key for an existing Log Analytics workspace. (`[[1]](diffhunk://#diff-03312c64375e41223f43bbe96ed808068991bfcd52b0fc01c28e416a7699255aR18-R26)`, `[[2]](diffhunk://#diff-4e715860a7dd565a29df148c455baab1f0b0f68073215ed7cf9c86b00257deabR13-R21)`)
* **Parameter Values**: Updated `src/HelloAspireApp.AppHost/infra/main.parameters.json` to include placeholder values for the new parameters. (`[src/HelloAspireApp.AppHost/infra/main.parameters.jsonR16-R24](diffhunk://#diff-6af61ea4da569b802ab7f1e53ff14af163081f3f8d73a6d93c66cfff4999c9deR16-R24)`)

### Conditional Resource Deployment:

* **Log Analytics Workspace Creation**: Modified `src/HelloAspireApp.AppHost/infra/resources.bicep` to create a new Log Analytics workspace only if an existing one is not provided. (`[src/HelloAspireApp.AppHost/infra/resources.bicepL45-R55](diffhunk://#diff-4e715860a7dd565a29df148c455baab1f0b0f68073215ed7cf9c86b00257deabL45-R55)`)
* **Reference to Existing Workspace**: Added logic to reference an existing Log Analytics workspace if its ID is provided. (`[src/HelloAspireApp.AppHost/infra/resources.bicepR66-R71](diffhunk://#diff-4e715860a7dd565a29df148c455baab1f0b0f68073215ed7cf9c86b00257deabR66-R71)`)

### Output Adjustments:

* **Dynamic Output Values**: Updated outputs in `src/HelloAspireApp.AppHost/infra/resources.bicep` to dynamically return values based on whether an existing Log Analytics workspace is used. (`[src/HelloAspireApp.AppHost/infra/resources.bicepL87-R112](diffhunk://#diff-4e715860a7dd565a29df148c455baab1f0b0f68073215ed7cf9c86b00257deabL87-R112)`)…ce references